### PR TITLE
Define volume for gophr-db

### DIFF
--- a/infra/images/dev/db/bin/run
+++ b/infra/images/dev/db/bin/run
@@ -31,6 +31,7 @@ $bin_dir/kill
 echo "Starting '$IMAGE_NAME:$IMAGE_TAG' container..."
 docker run \
   -d \
+  -v gophr-db:/var/lib/cassandra \
   -p 7000:7000 \
   -p 7001:7001 \
   -p 9042:9042 \

--- a/infra/images/dev/db/bin/run
+++ b/infra/images/dev/db/bin/run
@@ -5,6 +5,8 @@ IMAGE_TAG="dev"
 IMAGE_NAME="gophr-db"
 CONTAINER_NAME="gophr-db"
 DOCKER_MACHINE_NAME="gophr-dev"
+CONTAINER_VOLUME_NAME="cassandra-db-volume"
+DB_DIR="/var/lib/cassandra"
 
 # Get base directories
 bin_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -31,7 +33,7 @@ $bin_dir/kill
 echo "Starting '$IMAGE_NAME:$IMAGE_TAG' container..."
 docker run \
   -d \
-  -v gophr-db:/var/lib/cassandra \
+  -v "$CONTAINER_VOLUME_NAME:$DB_DIR" \
   -p 7000:7000 \
   -p 7001:7001 \
   -p 9042:9042 \


### PR DESCRIPTION
By defining a volume name and path our volume will persist after spinning down and up. This has been sort of a pain to deal with as I close my laptop and have to re-index, sometimes on mobile wifi. 

(I believe docker generates docker volumes for containers that don't specify one, but either they get deleted after spinning down or the container generates a new one. Have to double check that.)

Link to issue #73 