### PR TITLE
Replaced gin with sparkplug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+.sparkplug-bin

--- a/infra/images/dev/api/Dockerfile
+++ b/infra/images/dev/api/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:alpine
-# Install gin
+# Install sparkplug
 RUN set -ex && apk add --update 'git'
-# Install git
-RUN go get github.com/codegangsta/gin
+RUN go get github.com/skeswa/sparkplug
 # Set the environment variables for dev
 ENV PORT="3000"
 ENV GOPHR_ENV="dev"
@@ -13,4 +12,6 @@ EXPOSE 3000
 VOLUME ["/go/src/github.com/skeswa/gophr"]
 WORKDIR /go/src/github.com/skeswa/gophr
 # Get all the appropriate dependencies
-CMD cd ./api && go get -d -v && gin
+CMD cd ./api \
+    && go get -d -v \
+    && sparkplug

--- a/infra/images/dev/indexer/Dockerfile
+++ b/infra/images/dev/indexer/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:alpine
-# Install gin
+# Install sparkplug
 RUN set -ex && apk add --update 'git'
-# Install git
-RUN go get github.com/codegangsta/gin
+RUN go get github.com/skeswa/sparkplug
 # Set the environment variables for dev
 ENV PORT="3000"
 ENV GOPHR_ENV="dev"
@@ -13,4 +12,6 @@ EXPOSE 3000
 VOLUME ["/go/src/github.com/skeswa/gophr"]
 WORKDIR /go/src/github.com/skeswa/gophr
 # Get all the appropriate dependencies
-CMD cd ./indexer && go get -d -v && gin
+CMD cd ./indexer \
+    && go get -d -v \
+    && sparkplug

--- a/infra/images/dev/router/Dockerfile
+++ b/infra/images/dev/router/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:alpine
-# Install gin
+# Install sparkplug
 RUN set -ex && apk add --update 'git'
-# Install git
-RUN go get github.com/codegangsta/gin
+RUN go get github.com/skeswa/sparkplug
 # Set the environment variables for dev
 ENV PORT="3000"
 ENV GOPHR_ENV="dev"
@@ -13,4 +12,6 @@ EXPOSE 3000
 VOLUME ["/go/src/github.com/skeswa/gophr"]
 WORKDIR /go/src/github.com/skeswa/gophr
 # Get all the appropriate dependencies
-CMD cd ./router && go get -d -v && gin
+CMD cd ./router \
+    && go get -d -v \
+    && sparkplug


### PR DESCRIPTION
[`gin`](https://github.com/codegangsta/gin) isn't reliable, so I replaced it with something that is a little more dependable: [`sparkplug`](https://github.com/skeswa/sparkplug).