### PR TITLE
indexer now runs every day at 3 am

### DIFF
--- a/common/github/github.go
+++ b/common/github/github.go
@@ -36,3 +36,8 @@ func NewRequestService() *RequestService {
 
 	return &newRequestService
 }
+
+// TODO:(Shikkic) Create Param Struct
+type RequestServiceParams struct {
+	Indexer bool
+}

--- a/infra/docker/indexer/Dockerfile.dev
+++ b/infra/docker/indexer/Dockerfile.dev
@@ -33,7 +33,5 @@ ENV GOPHR_DB_ADDR="db"
 # Set the generated directory as the work directory.
 WORKDIR /gophr
 
-# Wait for db:9042 with no timeout, then start the binary.
-CMD ./wait-for-it.sh -h "$GOPHR_DB_ADDR" -p 9042 -t 0 \
-    -- \
-    ./gophr-indexer-binary --port "$PORT"
+COPY ./infra/docker/indexer/scripts/root /var/spool/cron/crontabs/root
+CMD crond -l 2 -f

--- a/infra/docker/indexer/Dockerfile.dev
+++ b/infra/docker/indexer/Dockerfile.dev
@@ -28,7 +28,7 @@ RUN set -ex && apk del git
 # Set the environment variables
 ENV PORT="3000"
 ENV GOPHR_ENV="dev"
-ENV GOPHR_DB_ADDR="db"
+ENV GOPHR_DB_ADDR="db-svc"
 
 # Set the generated directory as the work directory.
 WORKDIR /gophr

--- a/infra/docker/indexer/scripts/root
+++ b/infra/docker/indexer/scripts/root
@@ -1,0 +1,4 @@
+# TODO(Shikkic): remove first cron only for testing
+# min   hour    day     month   weekday command
+1       *       *       *       *       ./wait-for-it.sh -h "$GOPHR_DB_ADDR" -p 9042 -t 0 -- ./gophr-indexer-binary --port "$PORT"
+0       3       *       *       *	      ./wait-for-it.sh -h "$GOPHR_DB_ADDR" -p 9042 -t 0 -- ./gophr-indexer-binary --port "$PORT"

--- a/infra/docker/indexer/scripts/root
+++ b/infra/docker/indexer/scripts/root
@@ -1,4 +1,3 @@
 # TODO(Shikkic): remove first cron only for testing
 # min   hour    day     month   weekday command
-1       *       *       *       *       ./wait-for-it.sh -h "$GOPHR_DB_ADDR" -p 9042 -t 0 -- ./gophr-indexer-binary --port "$PORT"
-0       3       *       *       *	      ./wait-for-it.sh -h "$GOPHR_DB_ADDR" -p 9042 -t 0 -- ./gophr-indexer-binary --port "$PORT"
+0       3       *       *       *       /gophr/wait-for-it.sh -h "$GOPHR_DB_ADDR" -p 9042 -t 0 -- /gophr/gophr-indexer-binary --port "$PORT"


### PR DESCRIPTION
I found an old reference file we used to do this the first time [here](https://gist.github.com/andyshinn/3ae01fa13cb64c9d36e7)

I tested running random scripts inside of a container and it works, but I'm not sure if this is the right command we want for the indexer? Do we want to run wait-for-it before each index run?

I am also a bit unsure of how to test this with kubernetes